### PR TITLE
fix: 修复小屏设备页面显示异常、内容显示不完全

### DIFF
--- a/music-party-web/index.html
+++ b/music-party-web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
       <meta name="referrer" content="no-referrer" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Noto+Sans+SC:wght@400;500;700;900&display=swap" rel="stylesheet">

--- a/music-party-web/src/components/CenterConsole.vue
+++ b/music-party-web/src/components/CenterConsole.vue
@@ -8,9 +8,9 @@
       <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-[12vw] font-black text-medical-200/40 select-none whitespace-nowrap tracking-tighter blur-sm">
         {{ uiStore.backWords.toUpperCase() }}
       </div>
-      <!-- 四角标记 -->
-      <div class="absolute top-8 left-8 w-8 h-8 border-t-2 border-l-2 border-medical-300"></div>
-      <div class="absolute top-8 right-8 w-8 h-8 border-t-2 border-r-2 border-medical-300"></div>
+      <!-- 四角标记 (移动端下移，避开右上角浮动队列按钮) -->
+      <div class="absolute top-14 md:top-8 left-8 w-8 h-8 border-t-2 border-l-2 border-medical-300"></div>
+      <div class="absolute top-14 md:top-8 right-8 w-8 h-8 border-t-2 border-r-2 border-medical-300"></div>
       <div class="absolute bottom-8 left-8 w-8 h-8 border-b-2 border-l-2 border-medical-300"></div>
       <div class="absolute bottom-8 right-8 w-8 h-8 border-b-2 border-r-2 border-medical-300"></div>
     </div>

--- a/music-party-web/src/components/SearchModal.vue
+++ b/music-party-web/src/components/SearchModal.vue
@@ -1,25 +1,26 @@
 <template>
-  <div v-if="isOpen" class="fixed inset-0 z-[60] bg-medical-900/80 backdrop-blur-sm flex items-center justify-center p-4">
-    <div class="w-full max-w-4xl bg-medical-50 h-[85vh] md:h-[80vh] flex flex-col shadow-2xl relative chamfer-br max-h-full">
+  <div v-if="isOpen" class="fixed inset-0 z-[60] bg-medical-900/80 backdrop-blur-sm flex items-center justify-center p-0 md:p-4">
+    <!-- 移动端全屏面板；桌面端居中弹窗。安全区 padding 兼容刘海屏/全面屏 -->
+    <div class="w-full max-w-4xl bg-medical-50 h-full md:h-[80vh] flex flex-col shadow-2xl relative chamfer-br max-h-full pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
 
-      <!-- 关闭按钮 -->
-      <button @click="emit('close')" class="absolute top-0 right-0 p-4 hover:text-accent z-50">
+      <!-- 关闭按钮 (移动端避开刘海区域) -->
+      <button @click="emit('close')" class="absolute top-[env(safe-area-inset-top)] right-0 p-4 hover:text-accent z-50">
         <X class="w-6 h-6" />
       </button>
 
       <!-- 头部 -->
       <div class="p-4 md:p-6 border-b border-medical-200 bg-white flex-shrink-0">
-        <h2 class="text-xl md:text-2xl font-bold font-mono mb-4 text-medical-900 flex items-center gap-2">
+        <h2 class="text-xl md:text-2xl font-bold font-mono mb-3 md:mb-4 text-medical-900 flex items-center gap-2">
           <Search class="w-5 h-5 text-accent"/> SEARCH
         </h2>
 
-        <!-- 平台切换 TAB -->
-        <div class="flex gap-1 mb-4">
+        <!-- 平台切换 TAB (移动端收紧内边距，防小屏换行) -->
+        <div class="flex gap-1 mb-3 md:mb-4">
           <button
               v-for="p in ['netease', 'bilibili']" :key="p"
               @click="platform = p"
               :disabled="!isPlatformEnabled(p)"
-              class="px-6 py-2 text-sm font-bold uppercase transition-all"
+              class="px-4 md:px-6 py-2 text-sm font-bold uppercase transition-all"
               :class="[
                 platform === p ? 'bg-medical-900 text-white clip-tab' : 'bg-medical-200 text-medical-500 hover:bg-medical-300',
                 !isPlatformEnabled(p) ? 'opacity-30 cursor-not-allowed grayscale' : ''
@@ -35,7 +36,7 @@
               v-model="keyword"
               @keyup.enter="doSearch"
               placeholder="搜索音乐..."
-              class="flex-1 border p-3 outline-none transition-colors duration-300 font-sans bg-medical-100 border-medical-200 focus:border-accent"
+              class="flex-1 min-w-0 border p-2.5 md:p-3 outline-none transition-colors duration-300 font-sans bg-medical-100 border-medical-200 focus:border-accent"
           />
           <button
               @click="handleSearchAction"
@@ -57,7 +58,7 @@
             <span>用户歌单</span>
           </div>
 
-          <div class="flex-1 overflow-y-auto p-2 space-y-2">
+          <div class="flex-1 overflow-y-auto overscroll-contain p-2 space-y-2">
             <!-- 未绑定 -->
             <div v-if="!bindings[platform]" class="p-4 border border-dashed border-medical-300 bg-medical-50">
               <div class="text-xs text-medical-500 mb-2 text-center font-sans">绑定用户以获取用户歌单</div>
@@ -106,7 +107,7 @@
             <span class="font-bold text-sm text-medical-800">{{ listMode === 'search' ? 'SEARCH RESULTS' : 'PLAYLIST DETAILS' }}</span>
           </div>
 
-          <div @scroll="handleScroll" class="flex-1 overflow-y-auto p-2 md:p-4">
+          <div @scroll="handleScroll" class="flex-1 overflow-y-auto overscroll-contain p-2 md:p-4">
             <div v-if="loading" class="text-center py-10 font-mono text-accent animate-pulse">> LOADING DATA STREAM...</div>
 
             <!-- 歌单操作头 -->

--- a/music-party-web/src/components/layout/MainLayout.vue
+++ b/music-party-web/src/components/layout/MainLayout.vue
@@ -44,7 +44,7 @@ const handleSearchClick = () => {
         <div class="w-2.5 h-2.5 md:w-3 md:h-3 bg-accent flex-shrink-0"></div>
         <div class="flex items-baseline gap-1">
           <a href="https://github.com/PluvIIter/MusicParty" target="_blank" class="font-black text-base md:text-xl tracking-tighter text-medical-900 whitespace-nowrap hover:text-accent transition-colors">MUSIC PARTY</a>
-          <span class="text-medical-300 font-mono font-normal text-[10px] md:text-xs whitespace-nowrap">by {{ uiStore.authorName }}</span>
+          <span class="hidden sm:inline text-medical-300 font-mono font-normal text-[10px] md:text-xs whitespace-nowrap">by {{ uiStore.authorName }}</span>
         </div>
       </div>
 
@@ -102,7 +102,7 @@ const handleSearchClick = () => {
       </div>
 
       <Transition name="slide-fade">
-        <div v-if="mobileQueueOpen" class="md:hidden absolute inset-0 bg-white z-30 pt-4 overflow-y-auto">
+        <div v-if="mobileQueueOpen" class="md:hidden absolute inset-0 bg-white z-30 pt-4 overflow-y-auto overscroll-contain">
           <div class="px-4 pb-2 border-b border-medical-100 mb-2 flex justify-between">
             <span class="text-xs font-mono text-medical-400">QUEUE</span>
             <button @click="mobileQueueOpen = false"><X class="w-4 h-4"/></button>
@@ -112,7 +112,7 @@ const handleSearchClick = () => {
       </Transition>
 
       <Transition name="slide-fade">
-        <div v-if="mobileUserOpen" class="md:hidden absolute inset-0 bg-medical-50 z-30 pt-4 overflow-y-auto">
+        <div v-if="mobileUserOpen" class="md:hidden absolute inset-0 bg-medical-50 z-30 pt-4 overflow-y-auto overscroll-contain">
           <div class="px-4 pb-2 border-b border-medical-200 mb-2 flex justify-between">
             <span class="text-xs font-mono text-medical-400">OPERATIVES</span>
             <button @click="mobileUserOpen = false"><X class="w-4 h-4"/></button>
@@ -123,7 +123,7 @@ const handleSearchClick = () => {
     </div>
 
     <!-- 3. 精简模式视图 -->
-    <div v-else class="flex-1 flex flex-col items-center justify-center bg-medical-50 relative overflow-hidden p-6">
+    <div v-else class="flex-1 flex flex-col items-center justify-center bg-medical-50 relative overflow-hidden p-4 md:p-6">
       <!-- 背景装饰 -->
       <div class="absolute inset-0 z-0 pointer-events-none opacity-40">
         <div class="absolute inset-0 bg-[linear-gradient(rgba(17,24,39,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(17,24,39,0.03)_1px,transparent_1px)] bg-[size:32px_32px]"></div>
@@ -138,7 +138,7 @@ const handleSearchClick = () => {
         </div>
 
         <!-- 核心显示卡片 -->
-        <div class="w-full bg-white border border-medical-200 shadow-2xl relative p-8 chamfer-br">
+        <div class="w-full bg-white border border-medical-200 shadow-2xl relative p-5 md:p-8 chamfer-br">
            <!-- 四角修饰 -->
           <div class="absolute top-2 left-2 w-2 h-2 border-t border-l border-medical-300"></div>
           <div class="absolute top-2 right-2 w-2 h-2 border-t border-r border-medical-300"></div>


### PR DESCRIPTION
## 问题

在 iPhone SE2 这类小屏设备上，页面显示异常、内容显示不完全：

- 搜索弹窗在移动端仍是居中弹窗，小屏下内容被挤压、不完整；
- 刘海屏/全面屏设备上，顶部内容与状态栏重叠（safe-area 未处理）；
- 移动端右上角浮动队列按钮与主界面四角标记重叠；
- 精简模式卡片在小屏下内边距过大，内容溢出。
<img width="750" height="1106" alt="IMG_0138" src="https://github.com/user-attachments/assets/46dda1f9-4708-495e-8515-56ae0fee904b" />


## 改动

- **index.html**：viewport 增加 `viewport-fit=cover`，适配刘海屏安全区；
- **SearchModal**：移动端改为全屏面板 + `env(safe-area-inset-*)` padding，关闭按钮避开刘海，小屏收紧内边距防换行；
- **MainLayout**：小屏隐藏副标题、移动端面板 `overscroll-contain` 防滚动穿透、精简模式收紧内边距；
- **CenterConsole**：移动端四角标记下移，避开右上角浮动按钮。
<img width="750" height="1106" alt="IMG_0139" src="https://github.com/user-attachments/assets/4eb2e895-5f7b-452b-bec3-c30b5fe473fd" />


## 验证

- iPhone SE2 设备模拟（375×667）下各页面显示完整；
- 桌面端布局无回归。